### PR TITLE
pronto formatter default multiline to singleline

### DIFF
--- a/.github/actions/pronto-ruby/action.yml
+++ b/.github/actions/pronto-ruby/action.yml
@@ -5,7 +5,7 @@ inputs:
   formatters:
     description: 'Pick output formatters.'
     required: true
-    default: |
+    default: >-
       github_pr_review
       github_pr
   commit:


### PR DESCRIPTION
Prontoのformatter指定に改行が混ざっているので一行にする