### PR TITLE
bump rake version 12

### DIFF
--- a/test_gem.gemspec
+++ b/test_gem.gemspec
@@ -29,6 +29,6 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_development_dependency "bundler", "~> 2.0"
-  spec.add_development_dependency "rake", "~> 10.0"
+  spec.add_development_dependency "rake", "~> 12.0"
   spec.add_development_dependency "rspec", "~> 3.0"
 end


### PR DESCRIPTION
`warning: deprecated Object#=~ is called on Proc; it always returns nil`
がrake 12.3.2で修正されるようなので10系から12系にバージョンアップ
