### PR TITLE
fix comment

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
         ruby-version: ${{ matrix.ruby }}
     - name: Build and test with Rake
       run: |
-        # gem install bundler -v 2.1.4 # ruby 2.7.0以上であればデフォルトでインストール済み
+        # gem install bundler -v 2.1.2 # ruby 2.7.0以上であればデフォルトでインストール済み
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bundle exec rake


### PR DESCRIPTION
コメントのbundler versionをruby 2.7.0 にインストールされているものに修正